### PR TITLE
Wk9874/add moose input parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The exact contents of both of the above options can be obtained directly by clic
 
 ## Usage example
 ```python
-from simvue_integrations import FDSRun
+from simvue_integrations.connectors.moose import MooseRun
 
 ...
 
@@ -60,17 +60,19 @@ if __name__ == "__main__":
 
     # Using a context manager means that the status will be set to completed automatically,
     # and also means that if the code exits with an exception this will be reported to Simvue
-    with MOOSERun() as run:
+    with MooseRun() as run:
 
         # Specify a run name, metadata (dict), tags (list), description, folder
-        run.init('my-moose-simulation',
-                 {'simulation_type': 'thermal', 'heat_capacity': 900},               # Metadaata
-                 ['moose'],                                                          # Tags
-                 'MOOSE simulation of thermal properties of component.',             # Description
-                 '/component-1/thermal')                                             # Folder path
+        run.init(
+          name = 'my-moose-simulation',                                # Run name
+          {'simulation_type': 'thermal', 'heat_capacity': 900},        # Metadata
+          ['moose',],                                                  # Tags
+          'MOOSE simulation of thermal properties of component.',      # Description
+          '/component-1/thermal'                                       # Folder path
+        )
 
         # Set folder details if necessary
-        run.set_folder_details('/component-1/thermal',                 # Folder full path
+        run.set_folder_details('/component-1/thermal',                 # Full path to folder
                                metadata={},                            # Metadata
                                tags=['moose'],                         # Tags
                                description='Thermal study of design.') # Description
@@ -93,8 +95,7 @@ if __name__ == "__main__":
         run.launch(
             moose_application_path='app/moose-opt',   # Path to MOOSE application
             moose_file_path='thermal.i',              # Path to MOOSE input file
-            output_dir_path='results/thermal',        # Path to directory where results are stored
-            results_prefix="thermal",)                # Prefix for all results files
+            )
 
 ```
 

--- a/examples/moose/moose_example.py
+++ b/examples/moose/moose_example.py
@@ -62,9 +62,6 @@ def moose_example(moose_app_path, parallel = False) -> None:
         run.launch(
             moose_application_path=moose_app_path,
             moose_file_path=pathlib.Path(__file__).parent.joinpath("thermal_bar.i"),
-            # These should match those defined in the Outputs section of the MOOSE file:
-            output_dir_path="/tmp/simvue/results",
-            results_prefix="simvue_thermal",
             # You can optionally choose to track VectorPostProcessor outputs too:
             track_vector_postprocessors = True,
             track_vector_positions = False,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1601,13 +1601,13 @@ torch = ["torch"]
 
 [[package]]
 name = "packaging"
-version = "24.1"
+version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
-    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
+    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
+    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
 ]
 
 [[package]]
@@ -2649,13 +2649,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.13.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
-    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+    {file = "typer-0.13.0-py3-none-any.whl", hash = "sha256:d85fe0b777b2517cc99c8055ed735452f2659cd45e451507c76f48ce5c1d00e2"},
+    {file = "typer-0.13.0.tar.gz", hash = "sha256:f1c7198347939361eec90139ffa0fd8b3df3a2259d5852a0f7400e476d95985c"},
 ]
 
 [package.dependencies]

--- a/simvue_integrations/connectors/generic.py
+++ b/simvue_integrations/connectors/generic.py
@@ -27,6 +27,24 @@ class WrappedRun(simvue.Run):
     ):
         """
         Initialize the WrappedRun instance, extending the user supplied alert abort callback.
+
+        If `abort_callback` is provided the first argument must be this Run instance
+
+        Parameters
+        ----------
+        mode : Literal['online', 'offline', 'disabled'], optional
+            mode of running
+                online - objects sent directly to Simvue server
+                offline - everything is written to disk for later dispatch
+                disabled - disable monitoring completely
+        abort_callback : Callable | None, optional
+            callback executed when the run is aborted
+        server_token : str, optional
+            overwrite value for server token, default is None
+        server_url : str, optional
+            overwrite value for server URL, default is None
+        debug : bool, optional
+            run in debug mode, default is False
         """
 
         def _extended_abort_callback(self):

--- a/simvue_integrations/connectors/moose.py
+++ b/simvue_integrations/connectors/moose.py
@@ -76,7 +76,11 @@ class MooseRun(WrappedRun):
                     # Not interested in uploading long inputs like these as metadata, so ignore for now
                     if ";" in match.group(2):
                         continue
-                    input_metadata[f"{key}.{match.group(1)}"] = match.group(2).strip()
+                    try:
+                        val = float(match.group(2).strip())
+                    except ValueError:
+                        val = match.group(2).strip()
+                    input_metadata[f"{key}.{match.group(1)}"] = val
 
         self.update_metadata(input_metadata)
 

--- a/simvue_integrations/connectors/moose.py
+++ b/simvue_integrations/connectors/moose.py
@@ -87,7 +87,6 @@ class MooseRun(WrappedRun):
         # Try to retrieve some useful things
         if file_base := input_metadata.get(f"{prefix}.Outputs.file_base", None):
             self._output_dir_path, self._results_prefix = file_base.rsplit("/", 1)
-            print(self._results_prefix)
         else:
             raise KeyError(
                 "Could not find file_base in your MOOSE file.\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import simvue
 import uuid
-import subprocess
+import pathlib
 import time
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/integration/test_moose.py
+++ b/tests/integration/test_moose.py
@@ -37,10 +37,22 @@ def test_moose_connector(parallel):
     assert "Time Step 1, time = 2, dt = 2" in events
     
     # Check metrics uploaded from PostProcessor CSV
-    assert run_data["metrics"]["average_temperature"]["last"] > 499
+    assert run_data["metrics"]["average_temperature"]["last"] > 498
+    
+    # Check time and step data is correct
+    sample_metric = client.get_metric_values(metric_names=["average_temperature"], xaxis="time", output_format="dataframe", run_ids=[run_id])
+    assert list(sample_metric.index.levels[0]) == list(range(0, 32, 2))
+    sample_metric = client.get_metric_values(metric_names=["average_temperature"], xaxis="step", output_format="dataframe", run_ids=[run_id])
+    assert list(sample_metric.index.levels[0]) == list(range(0, 16, 1))
     
     # Check metrics uploaded from VectorPostProcessor CSV
-    assert run_data["metrics"]["temperature_along_bar.T.0"]["count"] == 15
+    assert run_data["metrics"]["temperature_along_bar.T.1"]["last"] > 498
+    
+    # Check time and step data is correct - starts from first step, since file PostProcessor file 0000 is blank
+    sample_metric = client.get_metric_values(metric_names=["temperature_along_bar.T.0"], xaxis="time", output_format="dataframe", run_ids=[run_id])
+    assert list(sample_metric.index.levels[0]) == list(range(2, 32, 2))
+    sample_metric = client.get_metric_values(metric_names=["temperature_along_bar.T.2"], xaxis="step", output_format="dataframe", run_ids=[run_id])
+    assert list(sample_metric.index.levels[0]) == list(range(1, 16, 1))
     
     temp_dir = tempfile.TemporaryDirectory()
     

--- a/tests/unit/moose/example_data/example_input_1.i
+++ b/tests/unit/moose/example_data/example_input_1.i
@@ -1,0 +1,85 @@
+# File from https://mooseframework.inl.gov/modules/thermal_hydraulics/tutorials/basics/input_file.html
+# Added file_base to Output section as this is a requirement for our connector
+
+# radius of a flow channel
+r = ${units 5 cm -> m}
+# cross-sectioanl area
+A_pipe = ${fparse pi * r * r}
+# hydraulic diameter
+D_h_pipe = ${fparse 2 * r}
+
+[GlobalParams]
+  initial_p = 1e5   # Pa
+  initial_vel = 0   # m/2
+  initial_T = 310   # K
+
+  closures = simple
+  rdg_slope_reconstruction = full
+[]
+
+[FluidProperties]
+  [fluid]
+    type = IdealGasFluidProperties
+  []
+[]
+
+[Components]
+  [pipe]
+    type = FlowChannel1Phase
+    position = '0 0 0'
+    orientation = '1 0 0'
+    length = 2
+    A = ${A_pipe}
+    D_h = ${D_h_pipe}
+    n_elems = 25
+    f = 0
+    fp = fluid
+  []
+
+  [inlet]
+    type = InletStagnationPressureTemperature1Phase
+    input = 'pipe:in'
+    p0 = 1.00001e5
+    T0 = 310
+  []
+
+  [outlet]
+    type = Outlet1Phase
+    input = 'pipe:out'
+    p = 1e5
+  []
+[]
+
+[Postprocessors]
+  [T_inlet]
+    type = SideAverageValue
+    boundary = pipe:in
+    variable = T
+  []
+[]
+
+[Preconditioning]
+  [pc]
+    type = SMP
+    full = true
+  []
+[]
+
+[Executioner]
+  type = Transient
+  start_time = 0
+  end_time = 1
+  dt = 0.1
+
+  solve_type = NEWTON
+  line_search = basic
+
+  nl_max_its = 5
+  nl_rel_tol = 1e-5
+[]
+
+[Outputs]
+  file_base = results/example_input_1
+  exodus = true
+  csv = true
+[]

--- a/tests/unit/moose/example_data/example_input_2.i
+++ b/tests/unit/moose/example_data/example_input_2.i
@@ -1,0 +1,50 @@
+# File from https://mooseframework.inl.gov/getting_started/examples_and_tutorials/examples/ex01_inputfile.html
+# Added file_base to Output section as this is a requirement for our connector
+
+[Mesh]
+  # We use a pre-generated mesh file (in exodus format).
+  # This mesh file has 'top' and 'bottom' named boundaries defined inside it.
+  #file = mug_2.e
+  file = mug.e
+[]
+
+[Variables]
+  [./diffused]
+    order = FIRST
+    family = LAGRANGE
+  [../]
+[]
+
+[Kernels]
+  [./diff]
+    type = Diffusion
+    variable = diffused
+  [../]
+[]
+
+[BCs]
+  [./bottom] # arbitrary user-chosen name
+    type = DirichletBC
+    variable = diffused
+    boundary = 'bottom' # This must match a named boundary in the mesh file
+    value = 1
+  [../]
+
+  [./top] # arbitrary user-chosen name
+    type = DirichletBC
+    variable = diffused
+    boundary = 'top' # This must match a named boundary in the mesh file
+    value = 0
+  [../]
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = 'PJFNK'
+[]
+
+[Outputs]
+  file_base = results/example_input_2
+  execute_on = 'timestep_end'
+  exodus = true
+[]

--- a/tests/unit/moose/example_data/example_input_3.i
+++ b/tests/unit/moose/example_data/example_input_3.i
@@ -1,0 +1,67 @@
+# File from https://mooseframework.inl.gov/getting_started/examples_and_tutorials/examples/ex07_ics.html
+# Added file_base to Output section as this is a requirement for our connector
+
+[Mesh]
+  file = half-cone.e
+[]
+
+[Variables]
+  [./diffused]
+    order = FIRST
+    family = LAGRANGE
+
+    # Use the initial Condition block underneath the variable
+    # for which we want to apply this initial condition
+    [./InitialCondition]
+      type = ExampleIC
+      coefficient = 2.0
+    [../]
+  [../]
+[]
+
+[Kernels]
+  [./td]
+    type = TimeDerivative
+    variable = diffused
+  [../]
+
+  [./diff]
+    type = Diffusion
+    variable = diffused
+  [../]
+[]
+
+[BCs]
+  [./left]
+    type = DirichletBC
+    variable = diffused
+    boundary = 'top'
+    value = 2
+  [../]
+
+  [./right]
+    type = DirichletBC
+    variable = diffused
+    boundary = 'bottom'
+    value = 8
+  [../]
+[]
+
+[Executioner]
+  type = Transient
+  dt = 0.1
+  start_time = 0
+  num_steps = 10
+
+  #Preconditioned = JFNK (default)
+  solve_type = 'PJFNK'
+
+
+[]
+
+[Outputs]
+  file_base = results/example_input_3
+  # Request that we output the initial condition so we can inspect
+  # the values with our visualization tool
+  exodus = true
+[]

--- a/tests/unit/moose/test_moose_file_upload.py
+++ b/tests/unit/moose/test_moose_file_upload.py
@@ -12,7 +12,12 @@ def mock_moose_process(self, *_, **__):
     # No need to do anything this time, just set termination trigger
     self._trigger.set()
     return True
-    
+
+def mock_input_parser(self, *_, **__):
+    self._output_dir_path = str(pathlib.Path(__file__).parent.joinpath("example_data", "moose_outputs"))
+    self._results_prefix = "moose_test"
+
+@patch.object(MooseRun, '_moose_input_parser', mock_input_parser)
 @patch.object(MooseRun, 'add_process', mock_moose_process)
 def test_moose_file_upload(folder_setup):
     """
@@ -26,9 +31,8 @@ def test_moose_file_upload(folder_setup):
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
-            output_dir_path=pathlib.Path(__file__).parent.joinpath("example_data", "moose_outputs"),
-            results_prefix="moose_test",
         )
+        print(run._output_dir_path)
         
         client = simvue.Client()
         
@@ -58,7 +62,8 @@ def mock_aborted_moose_process(self, *_, **__):
         
     thread = threading.Thread(target=aborted_process)
     thread.start()
-    
+
+@patch.object(MooseRun, '_moose_input_parser', mock_input_parser)
 @patch.object(MooseRun, 'add_process', mock_aborted_moose_process)    
 def test_moose_file_upload_after_abort(folder_setup):
     """
@@ -72,8 +77,6 @@ def test_moose_file_upload_after_abort(folder_setup):
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
-            output_dir_path=pathlib.Path(__file__).parent.joinpath("example_data", "moose_outputs"),
-            results_prefix="moose_test",
         )
     
     client = simvue.Client()

--- a/tests/unit/moose/test_moose_header_parser.py
+++ b/tests/unit/moose/test_moose_header_parser.py
@@ -12,27 +12,28 @@ def mock_moose_process(self, *_, **__):
     Mock process which creates the header of the MOOSE log (all at once, not line by line)
     """
     def create_header(self):
-        shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "moose_header.txt"), pathlib.Path(self.output_dir_path).joinpath(f"{self.results_prefix}.txt"))
+        shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "moose_header.txt"), pathlib.Path(self._output_dir_path).joinpath(f"{self._results_prefix}.txt"))
         time.sleep(1)
         self._trigger.set()
     thread = threading.Thread(target=create_header, args=(self,))
     thread.start()
-    
+
+@patch.object(MooseRun, '_moose_input_parser', lambda *_, **__: None)
 @patch.object(MooseRun, 'add_process', mock_moose_process)
 def test_moose_header_parser(folder_setup):   
     """
     Check information from header of MOOSE log is correctly uploaded as metadata
     """ 
-    name = 'test_moose_header_parser-%s' % str(uuid.uuid4())
     temp_dir = tempfile.TemporaryDirectory(prefix="moose_test")
+    name = 'test_moose_header_parser-%s' % str(uuid.uuid4())
     with MooseRun() as run:
         run.init(name=name, folder=folder_setup)
         run_id = run.id
+        run._output_dir_path = temp_dir.name
+        run._results_prefix = "moose_test"
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
-            output_dir_path=temp_dir.name,
-            results_prefix="moose_test",
         )
         
         client = simvue.Client()

--- a/tests/unit/moose/test_moose_input_parser.py
+++ b/tests/unit/moose/test_moose_input_parser.py
@@ -1,0 +1,75 @@
+from simvue_integrations.connectors.moose import MooseRun
+import uuid
+import simvue
+import pytest
+import pathlib
+testdata = [
+    (
+        "example_input_1",
+        {
+            "example_input_1.r": "${units 5 cm -> m}",
+            "example_input_1.GlobalParams.initial_T": 310,
+            "example_input_1.FluidProperties.fluid.type": "IdealGasFluidProperties",
+            "example_input_1.Components.pipe.position": "'0 0 0'",
+            "example_input_1.Postprocessors.T_inlet.boundary": "pipe:in",
+        },
+        {},
+    ),
+    (
+        "example_input_2",
+        {
+            "example_input_2.Mesh.file": "mug.e",
+            "example_input_2.Variables.diffused.order": "FIRST",
+            "example_input_2.BCs.bottom.value": 1,
+            "example_input_2.BCs.top.boundary": "'top'",
+        },
+        {
+            "example_input_2.BCs.bottom.boundary": "'bottom' # This must match a named boundary in the mesh file",
+            "example_input_2.BCs.bottom] # arbitrary user-chosen name.type": "Shouldn't exist",
+            "example_input_2.Mesh.#file": "mug_2.e"
+        },
+    ),
+    (
+        "example_input_3",
+        {
+            "example_input_3.Mesh.file": "half-cone.e",
+            "example_input_3.Variables.diffused.order": "FIRST",
+            "example_input_3.Kernels.td.type": "TimeDerivative",
+            "example_input_3.BCs.left.value": 2,
+            "example_input_3.Outputs.exodus": "true",
+        },
+        {
+            "example_input_3.Variables../diffused.order": "FIRST",
+            "example_input_3.Executioner.#Preconditioned": "JFNK (default)",
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("file_name,expected_metadata,not_expected_metadata", testdata, ids=(1, 2, 3))
+def test_moose_input_parser(folder_setup, file_name, expected_metadata, not_expected_metadata):   
+    """
+    Check information from MOOSE input file is correctly uploaded as metadata
+    """ 
+    with MooseRun() as run:
+        run.init(name='test_moose_input_parser-%s' % str(uuid.uuid4()), folder=folder_setup)
+        run_id = run.id
+        run._moose_input_parser(pathlib.Path(__file__).parent.joinpath("example_data", f"{file_name}.i"))
+
+        
+        client = simvue.Client()
+        metadata = client.get_run(run_id)['metadata']
+        # Check that keys and values parsed correctly
+        for key, value in expected_metadata.items():
+            assert metadata.get(key) == value
+    
+        for key, value in not_expected_metadata.items():
+            assert metadata.get(key) != value
+            
+        assert run._output_dir_path == "results"
+        assert run._results_prefix == file_name
+        
+        if file_name != "example_input_2":
+            assert run._dt == 0.1
+        
+        

--- a/tests/unit/moose/test_moose_log_parser.py
+++ b/tests/unit/moose/test_moose_log_parser.py
@@ -12,8 +12,8 @@ def mock_moose_process(self, *_, **__):
     Mock process which writes each entry in the example log file, line by line
     """
     temp_logfile = tempfile.NamedTemporaryFile(mode="w",prefix="moose_test_", suffix=".txt", buffering=1)
-    self.results_prefix = pathlib.Path(temp_logfile.name).name.split(".")[0]
-    self.output_dir_path = pathlib.Path(temp_logfile.name).parent
+    self._results_prefix = pathlib.Path(temp_logfile.name).name.split(".")[0]
+    self._output_dir_path = pathlib.Path(temp_logfile.name).parent
 
     def write_to_log():
         log_file = pathlib.Path(__file__).parent.joinpath("example_data", "moose_log.txt").open("r")
@@ -28,6 +28,7 @@ def mock_moose_process(self, *_, **__):
     thread = threading.Thread(target=write_to_log)
     thread.start()
     
+@patch.object(MooseRun, '_moose_input_parser', lambda *_, **__: None)   
 @patch.object(MooseRun, 'add_process', mock_moose_process)
 def test_moose_log_parser(folder_setup):    
     """
@@ -40,8 +41,6 @@ def test_moose_log_parser(folder_setup):
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
-            output_dir_path="overwritten_in_mocker",
-            results_prefix="overwritten_in_mocker",
         )
            
     client = simvue.Client()

--- a/tests/unit/moose/test_moose_scalarpostprocessor_parser.py
+++ b/tests/unit/moose/test_moose_scalarpostprocessor_parser.py
@@ -12,8 +12,8 @@ def mock_moose_process(self, *_, **__):
     Mock process for a MOOSE ScalarPostProcessor CSV file, written line by line.
     """
     temp_logfile = tempfile.NamedTemporaryFile(mode="w",prefix="moose_test_", suffix=".csv", buffering=1)
-    self.results_prefix = pathlib.Path(temp_logfile.name).name.split(".")[0]
-    self.output_dir_path = pathlib.Path(temp_logfile.name).parent
+    self._results_prefix = pathlib.Path(temp_logfile.name).name.split(".")[0]
+    self._output_dir_path = pathlib.Path(temp_logfile.name).parent
 
     def write_to_csv(temp_logfile=temp_logfile):
         log_file = pathlib.Path(__file__).parent.joinpath("example_data", "moose_temps_avgs.csv").open("r")
@@ -29,6 +29,7 @@ def mock_moose_process(self, *_, **__):
     thread = threading.Thread(target=write_to_csv)
     thread.start()
     
+@patch.object(MooseRun, '_moose_input_parser', lambda *_, **__: None) 
 @patch.object(MooseRun, 'add_process', mock_moose_process)
 def test_scalar_pp_parser(folder_setup):
     """
@@ -42,8 +43,6 @@ def test_scalar_pp_parser(folder_setup):
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
-            output_dir_path="overwritten_in_mocker",
-            results_prefix="overwritten_in_mocker",
         )
            
     client = simvue.Client()


### PR DESCRIPTION
# New Connector Feature - MOOSE Input File Parsing

## Connector(s) Edited
`MOOSERun`

## Description of Feature
The MOOSE connector now parses the input file before running the simulation, storing it as key value pairs which are uploaded as metadata to the run. This uses dot notation for the keys, so a file `input.i` with:
```
[Mesh]
    [generated]
      type = GeneratedMeshGenerator
```
would be stored as `'input.Mesh.generated.type' = 'GeneratedMeshGenerator'`

Does not support inputs which span multiple lines - if this happens, a `;` is typically provided at the end of the first line, so if we detect this then that key will not be added as metadata. This is most likely ok, since multi line inputs normally designate multi dimensional array inputs, which would not be useful pieces of metadata anyway.

This solves a couple of additional issues:
- Instead of needing the user to provide the `output_dir_path` and `results_prefix`, the connector will now find these automatically from the input file, raising an error if unable to do so. Currently the connector is limited to MOOSE inputs which use the default file structuring offered by MOOSE, so the whole outputs block should have a `file_base` parameter that is not overridden by individual outputs (this is not a new limitation and existed before this MR)
- the `dt` parameter for transient problems is read and stored as a class attribute. This means that we can accurately convert between `step` and `time` in case where only one is available (eg, Scalar PostProcessors only include a time measurement, and Vector PostProcessors only have step inferred from the file name if `time_data` is not set to True in the input file. This fixes #31 

## Testing Performed
- **Tested Software Version(s)**: git commit 87de105995 on 2024-08-08
- **Tested Operating System(s)**: Ubuntu 22.04
- **Tested Python Version(s)**: Python 3.10
- **Tested Simvue Python API Version(s)**: v1.1.2

Unit tests added to check file parser functionality against three input files taken from MOOSE documentation
Integration test improved to check for incorrect step / time data - now fails on `main`, but not on this branch
All other unit tests fixed to remove `output_dir_path` and `results_prefix` from .launch() call

## Documentation
- **Link to Documentation PR**: https://github.com/simvue-io/docs/pull/51

Fixed example and README to remove `output_dir_path` and `results_prefix` from .launch() call
Also fixed MooseRun import in README (#32)

## Links to Issues
Closes #31 
Closes #32 
Closes #34

## Comments
Could not use `pyhit` as I thought in the original issue - this is not released on `PyPI`, instead coming bundled with a MOOSE installation. To work it requires the user adding stuff to their `PYTHONPATH`, which I do not want to have be a requirement to use the connector. It also still wouldnt work for me seemingly due to issues with the `hit` C library.

## Checklist
- [ ] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [ ] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [ ] All unit tests run and pass locally
- [ ] Integration tests have been updated to use the new feature and are passing in the CI
- [ ] Code passes all pre-commit hooks
- [ ] The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)
- [ ] Example scripts have been updated to include your new feature
