### PR TITLE
MOOSE input parser swaps dots for underscores

### DIFF
--- a/simvue_integrations/connectors/moose.py
+++ b/simvue_integrations/connectors/moose.py
@@ -68,7 +68,9 @@ class MooseRun(WrappedRun):
                 # Eg [Mesh] - so look for square brackets with any characters between (already screened out end blocks above)
                 elif new_key := re.search(r"\[.+\]", line):
                     # Add the title of the new block to the key, dot separated notation
-                    key += f".{new_key.group().strip('[]/.')}"
+                    # Remove './' from before the titles of blocks if present
+                    # Replace a '.' with '_' to prevent issues with dot notation of keys, but still allow users to use dots in block names
+                    key += f".{new_key.group().strip('[]/').replace('./', '').replace('.', '_')}"
                 # Find lines which represent a key value pair, <key> = <value>
                 # Make sure to remove in line comments from the value
                 elif match := re.search(r"(\w*)\s*=\s*([^#]+)(#+.*)?", line):

--- a/tests/unit/moose/example_data/example_input_4.i
+++ b/tests/unit/moose/example_data/example_input_4.i
@@ -1,0 +1,99 @@
+[Mesh]
+    [generated]
+      type = GeneratedMeshGenerator
+      dim = 3
+      nx = 20
+      ny = 20
+      nz = 20
+      xmax = 6
+      ymax = 1
+      zmax = 1
+    []
+  []
+  [Variables]
+    [T]
+    []
+  []
+  [Kernels]
+    [time-derivative]
+      type = ADTimeDerivative
+      variable = T
+    []
+    [diffusion-kernel]
+      type = ADMatDiffusion    
+      variable = T
+      diffusivity = diffusivity-property
+    []
+  []
+  [Materials]
+    [mat-diffusivity]
+      type = ADGenericConstantMaterial
+      prop_names = 'diffusivity-property'
+      prop_values = '0.98'
+    []
+  []
+  [VectorPostprocessors]
+    [temps_line]
+      type = PointValueSampler
+      variable = 'T'
+      points = '0 0.5 0.5  1 0.5 0.5  2 0.5 0.5  3 0.5 0.5  4 0.5 0.5  5 0.5 0.5  6 0.5 0.5'
+      sort_by = 'x'
+    []
+  []
+  [Postprocessors]
+    [temp.avg]
+      type = ElementAverageValue
+      variable = 'T'
+      block = 0
+    []
+    [temp.max]
+      type = ElementExtremeValue
+      value_type = max
+      variable = 'T'
+      block = 0
+    []
+    [temp.min]
+      type = ElementExtremeValue
+      value_type = min
+      variable = 'T'
+      block = 0
+    []
+  []
+  [BCs]
+    [hot]
+      type = DirichletBC
+      variable = T
+      boundary = left
+      value = 1000
+    []
+    [cold]
+      type = DirichletBC
+      variable = T
+      boundary = right
+      value = 0
+    []
+  []
+  [Problem]
+    type = FEProblem
+  []
+  [Executioner]
+    type = Transient
+    end_time = 30
+    dt = 0.1
+    solve_type = NEWTON
+  []
+  [Outputs]
+    file_base = results/example_input_4
+    [exodus]
+      type = Exodus
+    []
+    [console]
+      type = Console
+      output_file = true
+    []
+    [csv]
+      type = CSV
+      show = 'temp.avg temp.max temp.min'
+    []
+  []
+  

--- a/tests/unit/moose/test_moose_input_parser.py
+++ b/tests/unit/moose/test_moose_input_parser.py
@@ -43,10 +43,22 @@ testdata = [
             "example_input_3.Executioner.#Preconditioned": "JFNK (default)",
         },
     ),
+    (
+        "example_input_4",
+        {
+            "example_input_4.Mesh.generated.type": "GeneratedMeshGenerator",
+            "example_input_4.VectorPostprocessors.temps_line.points": "'0 0.5 0.5  1 0.5 0.5  2 0.5 0.5  3 0.5 0.5  4 0.5 0.5  5 0.5 0.5  6 0.5 0.5'",
+            "example_input_4.Postprocessors.temp_avg.block": 0,
+            "example_input_4.Postprocessors.temp_max.variable": "'T'",
+        },
+        {
+            "example_input_4.Postprocessors.temp.avg.block": "Shouldn't exist",
+        },
+    ),
 ]
 
 
-@pytest.mark.parametrize("file_name,expected_metadata,not_expected_metadata", testdata, ids=(1, 2, 3))
+@pytest.mark.parametrize("file_name,expected_metadata,not_expected_metadata", testdata, ids=(1, 2, 3, 4))
 def test_moose_input_parser(folder_setup, file_name, expected_metadata, not_expected_metadata):   
     """
     Check information from MOOSE input file is correctly uploaded as metadata


### PR DESCRIPTION
# Hotfix - MOOSE input parser supports dot in block name

## Connector(s) Tested
MOOSE

## Description of Bug(s) and Fix(es)
Previously dots would be stripped from a block name when input file was parsed. Now instead './' is replaced with blank spaces, then '.' is replaced by an underscore. This means that name '[./Variables]' is just called 'file_name.Variables', while say '[temps.max]' will be 'file_name.temps_max'.

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [x] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [x] New unit tests have been added to check for this bug in the future
- [x] All unit tests run and pass locally
- [x] Integration tests are passing in the CI
- [x] Code passes all pre-commit hooks
