### PR TITLE
Add support for MOOSE Terminator

### DIFF
--- a/simvue_integrations/connectors/generic.py
+++ b/simvue_integrations/connectors/generic.py
@@ -99,7 +99,6 @@ class WrappedRun(simvue.Run):
         By default, checks whether an abort has been caused by an alert, and if so prints a message and sets
         the run to the terminated state. This method should be called AFTER the rest of your functions in the overriden method.
         """
-        print("inside generic post")
         if self._alert_raised_trigger.is_set():
             self.log_event("Simulation aborted due to an alert being triggered.")
             self._terminated = True
@@ -109,9 +108,7 @@ class WrappedRun(simvue.Run):
                 bold=self._term_color,
             )
         else:
-            print("before log event")
             self.log_event("Simulation Complete!")
-            print("after log event")
 
     def __exit__(self, exc_type, value, traceback):
         _out = super().__exit__(exc_type, value, traceback)

--- a/simvue_integrations/connectors/moose.py
+++ b/simvue_integrations/connectors/moose.py
@@ -286,7 +286,7 @@ class MooseRun(WrappedRun):
 
         if self._dt and not metric_step:
             # Has come from a scalar PostProcessor, can assume step = time / dt
-            metric_step = metric_time / self._dt
+            metric_step = int(metric_time / self._dt)
 
         # Log all results for this timestep as Metrics
         self.log_metrics(

--- a/tests/unit/moose/example_data/moose_log.txt
+++ b/tests/unit/moose/example_data/moose_log.txt
@@ -230,4 +230,11 @@ Time Step 2, time = 2, dt = 1
      49 Linear |R| = 1.495263e-09
  2 Nonlinear |R| = 1.495259e-09
  Solve Converged!
+
+*** Warning ***
+/home/wk9874/Documents/simvue/integrations/workspace/copper_mug.i:131.5:
+The following warning occurred in the UserObject 'handle-too-hot' of type Terminator.
+
+Terminator 'handle-too-hot' is causing the execution to terminate.
+
 Finished Executing 

--- a/tests/unit/moose/test_moose_file_upload.py
+++ b/tests/unit/moose/test_moose_file_upload.py
@@ -32,7 +32,6 @@ def test_moose_file_upload(folder_setup):
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),
         )
-        print(run._output_dir_path)
         
         client = simvue.Client()
         

--- a/tests/unit/moose/test_moose_header_parser.py
+++ b/tests/unit/moose/test_moose_header_parser.py
@@ -29,8 +29,10 @@ def test_moose_header_parser(folder_setup):
     with MooseRun() as run:
         run.init(name=name, folder=folder_setup)
         run_id = run.id
+        # Set these here instead of them being read from a MOOSE input file
         run._output_dir_path = temp_dir.name
         run._results_prefix = "moose_test"
+
         run.launch(
             moose_application_path=pathlib.Path(__file__),
             moose_file_path=pathlib.Path(__file__),


### PR DESCRIPTION
# New Connector Feature - Support for MOOSE Terminator

## Connector(s) Edited
MooseRun
## Description of Feature
Moose provides functionality to stop runs early with the Terminator (https://mooseframework.inl.gov/source/userobjects/Terminator.html). The connector now supports this by looking out for the line which is added to the MOOSE log file when the terminator is triggered:
```
Terminator 'handle-too-hot' is causing the execution to terminate.
```
If seen, the connector will:
- Add that line to the events log
- Add {'handle-too-hot': True} to the metadata
- Add 'handle-too-hot' as a tag
- Set the run status to 'terminated'

## Documentation
- **Link to Documentation PR**: https://github.com/simvue-io/docs/pull/52

## Links to Issues
Closes #38 

## Comments
Only works when `error-level` is set to `WARNING` in the moose input file - if set to `ERROR`, the moose simulation itself will return a non zero exit code which stops the connector, and if `INFO` then it is not recorded in the log file. Added a note to reflect this in the docs.

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] ~~Any new Python package requirements have been added as an Extra to the `pyproject.toml`~~
- [x] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [x] All unit tests run and pass locally
- [ ] Integration tests have been updated to use the new feature and are passing in the CI
- [x] Code passes all pre-commit hooks
- [x] The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)
- [ ] ~~Example scripts have been updated to include your new feature~~
