### PR TITLE
Optional Results Deletion in FDSRun

### DIFF
--- a/simvue_integrations/connectors/fds.py
+++ b/simvue_integrations/connectors/fds.py
@@ -379,7 +379,7 @@ class FDSRun(WrappedRun):
         if self.workdir_path:
             pathlib.Path(self.workdir_path).mkdir(exist_ok=True)
 
-            if upload_files:
+            if clean_workdir:
                 for file in pathlib.Path(self.workdir_path).glob(f"{self._chid}*"):
                     if (
                         pathlib.Path(file).absolute()

--- a/tests/unit/fds/test_fds_file_deletion.py
+++ b/tests/unit/fds/test_fds_file_deletion.py
@@ -1,0 +1,73 @@
+from simvue_integrations.connectors.fds import FDSRun
+import pathlib
+from unittest.mock import patch
+import tempfile
+import uuid
+import simvue
+import filecmp
+import shutil
+import time
+import threading
+
+def mock_fds_process(self, *_, **__):
+    """
+    Mock process - does nothing but set termination trigger
+    """
+    time.sleep(1)
+    self._trigger.set()
+    return True
+    
+@patch.object(FDSRun, 'add_process', mock_fds_process)
+def test_fds_file_deletion(folder_setup):    
+    """
+    Check that files beginning with CHID are deleted from workdir.
+    """    
+    name = 'test_fds_file_deletion-%s' % str(uuid.uuid4())
+    temp_dir = tempfile.TemporaryDirectory(prefix="fds_test")
+    
+    # Copy results into workdir
+    shutil.copytree(pathlib.Path(__file__).parent.joinpath("example_data", "fds_outputs"), temp_dir.name, dirs_exist_ok=True)
+    # Create a file which doesn't start with chid - shouldn't ever be deleted
+    pathlib.Path(temp_dir.name).joinpath("test.txt").touch()
+    # Copy in an input file - also shouldn't be deleted
+    shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "fds_input.fds"), temp_dir.name)
+    
+    with FDSRun() as run:
+        run.init(name=name, folder=folder_setup)
+        run_id = run.id
+        run.launch(
+            fds_input_file_path = pathlib.Path(temp_dir.name).joinpath("fds_input.fds"),
+            workdir_path = temp_dir.name,
+            clean_workdir = True
+        )
+        
+        comparison = filecmp.dircmp(pathlib.Path(__file__).parent.joinpath("example_data", "fds_outputs"), temp_dir.name)
+        assert sorted(comparison.left_only) == sorted(["fds_test.smv", "fds_test_1_1.s3d.sz", "fds_test_1_1.sf.bnd"])
+        assert sorted(comparison.right_only) == sorted(["test.txt", "fds_input.fds"])
+        
+@patch.object(FDSRun, 'add_process', mock_fds_process)
+def test_fds_no_file_deletion(folder_setup):    
+    """
+    Check that no files are deleted if clean is not specified.
+    """    
+    name = 'test_fds_no_file_deletion-%s' % str(uuid.uuid4())
+    temp_dir = tempfile.TemporaryDirectory(prefix="fds_test")
+    
+    # Copy results into workdir
+    shutil.copytree(pathlib.Path(__file__).parent.joinpath("example_data", "fds_outputs"), temp_dir.name, dirs_exist_ok=True)
+    # Create a file which doesn't start with chid - shouldn't ever be deleted
+    pathlib.Path(temp_dir.name).joinpath("test.txt").touch()
+    # Copy in an input file - also shouldn't be deleted
+    shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "fds_input.fds"), temp_dir.name)
+    
+    with FDSRun() as run:
+        run.init(name=name, folder=folder_setup)
+        run_id = run.id
+        run.launch(
+            fds_input_file_path = pathlib.Path(temp_dir.name).joinpath("fds_input.fds"),
+            workdir_path = temp_dir.name,
+        )
+        
+        comparison = filecmp.dircmp(pathlib.Path(__file__).parent.joinpath("example_data", "fds_outputs"), temp_dir.name)
+        assert not comparison.left_only
+        assert sorted(comparison.right_only) == sorted(["test.txt", "fds_input.fds"])

--- a/tests/unit/moose/test_moose_file_upload.py
+++ b/tests/unit/moose/test_moose_file_upload.py
@@ -43,15 +43,7 @@ def test_moose_file_upload(folder_setup):
 def mock_aborted_moose_process(self, *_, **__):
     """
     Mock a long running MOOSE process which is aborted by the server
-    """
-    def abort():
-        """
-        Instead of making an API call to the server, just sleep for 1s and return True to indicate an abort has been triggered
-        """
-        time.sleep(1)
-        return True
-    self._simvue.get_abort_status = abort
-    
+    """ 
     def aborted_process():
         """
         Long running process which should be interrupted at the next heartbeat
@@ -61,6 +53,13 @@ def mock_aborted_moose_process(self, *_, **__):
         
     thread = threading.Thread(target=aborted_process)
     thread.start()
+
+def abort():
+    """
+    Instead of making an API call to the server, just sleep for 1s and return True to indicate an abort has been triggered
+    """
+    time.sleep(1)
+    return True   
 
 @patch.object(MooseRun, '_moose_input_parser', mock_input_parser)
 @patch.object(MooseRun, 'add_process', mock_aborted_moose_process)    
@@ -72,6 +71,7 @@ def test_moose_file_upload_after_abort(folder_setup):
     temp_dir = tempfile.TemporaryDirectory(prefix="moose_test")
     with MooseRun() as run:
         run.init(name=name, folder=folder_setup)
+        run._simvue.get_abort_status = abort
         run_id = run.id
         run.launch(
             moose_application_path=pathlib.Path(__file__),


### PR DESCRIPTION
# New Connector Feature - Clean Workdir

## Connector(s) Edited
FDSRun

## Description of Feature
Previously the FDSRun connector would automatically remove any FDS results files starting with the CHID from the workdir supplied. Now it will only do this if the user specifies `clean_workdir`.

## Testing Performed
- **Tested Software Version(s)**: 6.9.1
- **Tested Operating System(s)**: Ubuntu
- **Tested Python Version(s)**: 3.10
- **Tested Simvue Python API Version(s)**: v1.1.2

## Documentation
- **Link to Documentation PR**: https://github.com/simvue-io/docs/pull/53

## Links to Issues
Closes #42 

## Comments
Test `tests/unit/fds/test_fds_csv_parser.py::test_fds_ctrl_parser` expected to fail

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] ~~Any new Python package requirements have been added as an Extra to the `pyproject.toml`~~
- [x] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [x] All unit tests run and pass locally
- [x] Integration tests have been updated to use the new feature and are passing in the CI
- [x] Code passes all pre-commit hooks
- [x] The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)
- [x] Example scripts have been updated to include your new feature
