### PR TITLE
Add check for if dt is not a number

### DIFF
--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -38,12 +38,16 @@ jobs:
     container:
       image: idaholab/moose:latest
     steps:
+      - name: Make new user
+        run: |
+          useradd -g root -m dev
+          su - dev
       - uses: actions/checkout@v4
       - name: Install poetry
         run: python -m pip install poetry
       - name: Install dependencies and run tests
         run: |
-          export PATH=/opt/mpich/bin:$PATH
+          export PATH=/opt/openmpi/bin:$PATH
           export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
           export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
           poetry install --with dev

--- a/.github/workflows/test_integration.yml
+++ b/.github/workflows/test_integration.yml
@@ -38,10 +38,6 @@ jobs:
     container:
       image: idaholab/moose:latest
     steps:
-      - name: Make new user
-        run: |
-          useradd -g root -m dev
-          su - dev
       - uses: actions/checkout@v4
       - name: Install poetry
         run: python -m pip install poetry

--- a/examples/moose/moose_example.py
+++ b/examples/moose/moose_example.py
@@ -67,7 +67,8 @@ def moose_example(moose_app_path, parallel = False) -> None:
             track_vector_positions = False,
             # And you can choose whether to run it in parallel
             run_in_parallel = parallel,
-            num_processors = 2
+            num_processors = 2,
+            mpiexec_env_vars = {"allow-run-as-root": True}
         )
 
         # Once the simulation is complete, you can upload any final items to the Simvue run before it closes

--- a/simvue_integrations/connectors/moose.py
+++ b/simvue_integrations/connectors/moose.py
@@ -96,7 +96,12 @@ class MooseRun(WrappedRun):
             )
 
         if _dt := input_metadata.get(f"{prefix}.Executioner.dt", None):
-            self._dt = float(_dt)
+            try:
+                self._dt = float(_dt)
+            except ValueError:
+                print(
+                    "WARNING: Could not interpret Executioner.dt as a number, falling back to log times and steps. To correct this, make sure 'dt' is a number in your MOOSE input file."
+                )
 
     @mp_file_parser.file_parser
     def _moose_header_parser(self, input_file: str, **__) -> typing.Dict[str, str]:

--- a/simvue_integrations/connectors/tensorflow.py
+++ b/simvue_integrations/connectors/tensorflow.py
@@ -122,8 +122,8 @@ class TensorVue(Callback):
         self.eval_run = evaluation_run
 
         if alert_definitions:
-            for alert_definition in alert_definitions.values():
-                validators.AlertValidator(**alert_definition)
+            for alert_name, alert_definition in alert_definitions.items():
+                validators.AlertValidator(name=alert_name, **alert_definition)
 
         self.alert_definitions = alert_definitions or {}
         self.manifest_alerts = manifest_alerts or []

--- a/simvue_integrations/extras/validators.py
+++ b/simvue_integrations/extras/validators.py
@@ -1,21 +1,28 @@
 """Common
 ----------
-
 Classses which could be used in the construction of multiple adapters.
 """
+# ruff: noqa: DOC201
+
 import enum
-import typing
-import pydantic
-#temp
+from typing import Callable, Literal, Optional, Union
+from pydantic import BaseModel, Field, PositiveInt, ValidationInfo, field_validator
+
+NAME_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:]+$"
+
+
+# temp
 class Operator(str, enum.Enum):
     """The operator to use to compare the reduced evaluation value to a given target threshold."""
+
     MORE_THAN = ">"
     LESS_THAN = "<"
     MORE_EQUAL = ">="
     LESS_EQUAL = "<="
     EQUAL = "=="
 
-OPERATORS: dict[str, typing.Callable[[typing.Union[int, float], typing.Union[int, float]], bool]] = {
+
+OPERATORS: dict[str, Callable[[Union[int, float], Union[int, float]], bool]] = {
     ">": lambda x, y: x > y,
     "<": lambda x, y: x < y,
     ">=": lambda x, y: x >= y,
@@ -23,67 +30,136 @@ OPERATORS: dict[str, typing.Callable[[typing.Union[int, float], typing.Union[int
     "==": lambda x, y: x == y,
 }
 
+
 def check_input(
-        value_to_check: typing.Union[str, float, int, None], 
-        validation_info: pydantic.ValidationInfo, 
-        name_of_parameter: str, 
-        required_when_name: str, 
-        required_when_values: list
-        ):
+    value_to_check: Union[str, float, int, None],
+    validation_info: ValidationInfo,
+    name_of_parameter: str,
+    required_when_name: str,
+    required_when_values: list,
+) -> Union[str, float, int, None]:
+    """Checks that alert fields are correctly defined in cases where parameters are only required if another parameter is set.
+
+    Parameters
+    ----------
+    value_to_check : Union[str, float, int, None]
+        The value entered for the field being validated
+    validation_info : ValidationInfo
+        The values given for all other fields defined in the validator up to this point
+    name_of_parameter : str
+        The name of the field being validated
+    required_when_name : str
+        The name of the parameter which defines whether the field is required
+    required_when_values : list
+        The values of the parameter above which mean that the field is required
+
+    Returns
+    -------
+    value_to_check : Union[str, float, int, None]
+        The validated value
+
+    Raises
+    ------
+    ValueError
+        Raised if the parameter IS required but has NOT been provided, or if the parameter is NOT required but HAS been provided
+    """
     other_values = validation_info.data
-    if other_values.get(required_when_name) in required_when_values:
-        assert value_to_check, f"'{name_of_parameter}' must be provided for alerts using '{required_when_name} = {other_values.get(required_when_name)}'."
-    elif other_values.get(required_when_name) not in required_when_values:
-        assert not value_to_check, f"'{name_of_parameter}' must not be provided for alerts using '{required_when_name} = {other_values.get(required_when_name)}'."
+    if (
+        other_values.get(required_when_name) in required_when_values
+    ) and value_to_check is None:
+        raise ValueError(
+            f"'{name_of_parameter}' must be provided for alerts using '{required_when_name} = {other_values.get(required_when_name)}'."
+        )
+    elif (
+        other_values.get(required_when_name) not in required_when_values
+    ) and value_to_check is not None:
+        raise ValueError(
+            f"'{name_of_parameter}' must not be provided for alerts using '{required_when_name} = {other_values.get(required_when_name)}'."
+        )
     return value_to_check
 
-class AlertValidator(pydantic.BaseModel, extra='forbid'):
-    source: typing.Literal["metrics", "events"]
-    frequency: pydantic.PositiveInt
-    notification: typing.Optional[typing.Literal["none", "email"]] = pydantic.Field(default="none")
-    description: typing.Optional[str] = pydantic.Field(default=None)
+
+class AlertValidator(BaseModel, extra="forbid"):  # type: ignore
+    name: Optional[str] = Field(None, pattern=NAME_REGEX)
+    source: Literal["metrics", "events", "user"]
+    frequency: Optional[PositiveInt] = Field(default=None, validate_default=True)
+    notification: Optional[Literal["none", "email"]] = Field(default="none")
+    description: Optional[str] = Field(default=None)
     # For event based alerts:
-    pattern: typing.Optional[str] = pydantic.Field(default=None, validate_default=True)
+    pattern: Optional[str] = Field(default=None, validate_default=True)
     # For metric based alerts:
-    rule: typing.Optional[typing.Literal["is above", "is below", "is outside range", "is inside range"]] = pydantic.Field(default=None, validate_default=True)
-    metric: typing.Optional[str] = pydantic.Field(default=None, validate_default=True)
-    window: typing.Optional[pydantic.PositiveInt] = pydantic.Field(default=None, validate_default=True)
+    rule: Optional[
+        Literal["is above", "is below", "is outside range", "is inside range"]
+    ] = Field(default=None, validate_default=True)
+    metric: Optional[str] = Field(default=None, validate_default=True)
+    window: Optional[PositiveInt] = Field(default=None, validate_default=True)
     # For 'is above' or 'is below':
-    threshold: typing.Optional[typing.Union[int, float]] = pydantic.Field(default=None, validate_default=True)
+    threshold: Optional[Union[int, float]] = Field(default=None, validate_default=True)
     # For 'is outside range' or 'is inside range'
-    range_low: typing.Optional[typing.Union[int, float]] = pydantic.Field(default=None, validate_default=True)
-    range_high: typing.Optional[typing.Union[int, float]] = pydantic.Field(default=None, validate_default=True)
-    aggregation: typing.Optional[typing.Literal["average", "sum", "at least one", "all"]] = pydantic.Field(default="average", validate_default=True)
-    trigger_abort: typing.Optional[bool] = pydantic.Field(default=None, validate_default=True)
-        
-    @pydantic.field_validator("pattern")
+    range_low: Optional[Union[int, float]] = Field(default=None, validate_default=True)
+    range_high: Optional[Union[int, float]] = Field(default=None, validate_default=True)
+    aggregation: Optional[Literal["average", "sum", "at least one", "all"]] = Field(
+        default="average"
+    )
+    trigger_abort: Optional[bool] = Field(default=None, validate_default=True)
+
+    @field_validator("frequency")
+    def check_frequency(cls, v, validation_info):
+        """Checks that frequency is specified if the alert source is metrics or events."""
+        return check_input(
+            v, validation_info, "frequency", "source", ["metrics", "events"]
+        )
+
+    @field_validator("pattern")
     def check_pattern(cls, v, validation_info):
+        """Checks that pattern is specified if the alert source is events."""
         return check_input(v, validation_info, "pattern", "source", ["events"])
-    
-    @pydantic.field_validator("rule")
+
+    @field_validator("rule")
     def check_rule(cls, v, validation_info):
+        """Checks that rule is specified if the alert source is metrics."""
         return check_input(v, validation_info, "rule", "source", ["metrics"])
-    
-    @pydantic.field_validator("metric")
+
+    @field_validator("metric")
     def check_metric(cls, v, validation_info):
+        """Checks that metric is specified if the alert source is metrics."""
         return check_input(v, validation_info, "metric", "source", ["metrics"])
-    
-    @pydantic.field_validator("aggregation")
+
+    @field_validator("aggregation")
     def check_aggregation(cls, v, validation_info):
+        """Checks that aggregation is specified if the alert source is metrics."""
         return check_input(v, validation_info, "aggregation", "source", ["metrics"])
-    
-    @pydantic.field_validator("window")
+
+    @field_validator("window")
     def check_window(cls, v, validation_info):
+        """Checks that window is specified if the alert source is metrics."""
         return check_input(v, validation_info, "window", "source", ["metrics"])
 
-    @pydantic.field_validator("threshold")
+    @field_validator("threshold")
     def check_threshold(cls, v, validation_info):
-        return check_input(v, validation_info, "threshold", "rule", ["is above", "is below"])
-    
-    @pydantic.field_validator("range_low")
+        """Checks that threshold is specified if the alert rule is 'is above' or 'is below'."""
+        return check_input(
+            v, validation_info, "threshold", "rule", ["is above", "is below"]
+        )
+
+    @field_validator("range_low")
     def check_range_low(cls, v, validation_info):
-        return check_input(v, validation_info, "range_low", "rule", ["is outside range", "is inside range"])
-    
-    @pydantic.field_validator("range_high")
+        """Checks that range_low is specified if the alert rule is 'is outside range' or 'is inside range'."""
+        return check_input(
+            v,
+            validation_info,
+            "range_low",
+            "rule",
+            ["is outside range", "is inside range"],
+        )
+
+    @field_validator("range_high")
     def check_range_high(cls, v, validation_info):
-        return check_input(v, validation_info, "range_high", "rule", ["is outside range", "is inside range"])
+        """Checks that range_high is specified if the alert rule is 'is outside range' or 'is inside range'."""
+        return check_input(
+            v,
+            validation_info,
+            "range_high",
+            "rule",
+            ["is outside range", "is inside range"],
+        )

--- a/tests/unit/moose/example_data/example_input_4.i
+++ b/tests/unit/moose/example_data/example_input_4.i
@@ -79,7 +79,7 @@
   [Executioner]
     type = Transient
     end_time = 30
-    dt = 0.1
+    dt = $my_dt
     solve_type = NEWTON
   []
   [Outputs]

--- a/tests/unit/moose/test_moose_input_parser.py
+++ b/tests/unit/moose/test_moose_input_parser.py
@@ -81,7 +81,9 @@ def test_moose_input_parser(folder_setup, file_name, expected_metadata, not_expe
         assert run._output_dir_path == "results"
         assert run._results_prefix == file_name
         
-        if file_name != "example_input_2":
+        if file_name in ("example_input_1", "example_input_3"):
             assert run._dt == 0.1
+        else:
+            assert run._dt == None
         
         

--- a/tests/unit/tensorflow/test_tensorflow_alerts.py
+++ b/tests/unit/tensorflow/test_tensorflow_alerts.py
@@ -35,8 +35,13 @@ def test_adding_alerts(folder_setup, tensorflow_example_data):
                 "trigger_abort": False,
                 "notification": "email",
             },
+            "model_diverged": {
+                "source": "events",
+                "frequency": 1,
+                "pattern": "Model diverged with loss = NaN",
+            },
         },
-        simulation_alerts=["loss_above_half"],
+        simulation_alerts=["loss_above_half", "model_diverged"],
         evaluation_alerts=["loss_above_half","accuracy_below_80_percent"],
         epoch_alerts=["accuracy_below_80_percent"],
         start_alerts_from_epoch=2
@@ -69,8 +74,8 @@ def test_adding_alerts(folder_setup, tensorflow_example_data):
     epoch_run_3 = client.get_runs(filters=[f'name contains {run_name}_epoch_3'], alerts=True)[0]
     
     # Check simulaiton run has one alert added, and that is 'loss_above_half'
-    assert len(simulation_run["alerts"]) == 1
-    assert simulation_run["alerts"][0]["alert"]["name"] == "loss_above_half"
+    assert len(simulation_run["alerts"]) == 2
+    assert [alert["alert"]["name"] for alert in simulation_run["alerts"]] == ["loss_above_half", "model_diverged"]
     
     # Check evaluation run has both alerts added
     assert len(evaluation_run["alerts"]) == 2
@@ -133,6 +138,13 @@ invalid_alerts = [
             "window": 1,
             "threshold": 0.8,
             "new": "hi"
+        },
+    # Shouldn't specify aggregation when source is events
+    {
+            "source": "events",
+            "frequency": 1,
+            "pattern": "test pattern",
+            "aggregation": "sum",
         },
 ]
 


### PR DESCRIPTION
# Hotfix - MOOSE input with non numerical dt crashed connector

## Connector(s) Tested
MooseRun

## Description of Bug(s) and Fix(es)
If the MOOSE input file has `dt` as a non number, eg if it was `$dt` which is then replaced at runtime with something defined elsewhere in the file, then MooseRun would crash. Now added a try except to catch this case, print a warning, and continue with fallback option of reading dt from log.

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [x] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [x] New unit tests have been added to check for this bug in the future
- [x] All unit tests run and pass locally
- [x] Integration tests are passing in the CI
- [x] Code passes all pre-commit hooks
